### PR TITLE
Fixed crash on client disconnect (tornado-websocket-server.py)

### DIFF
--- a/tornado-websocket-server.py
+++ b/tornado-websocket-server.py
@@ -39,6 +39,7 @@ class WSHandler(tornado.websocket.WebSocketHandler):
     self.write_message(message)
 
   def on_close(self):
+    self.connections.discard(self) #I think this was the killer line :) -JM
     print 'connection closed...'
 
 application = tornado.web.Application([


### PR DESCRIPTION
Fixed (tornado-websocket-server.py)
The function WSHandler.on_close() did not safely discard the client connection.
Added the line self.connections.discard(self) to this function.
Tested it with a few simultaneous clients and I couldn't break it.
